### PR TITLE
feat: create mechanisms that automatically calculates test resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,10 @@ env:
 
   # Automatically define CPU, memory, message generators and concurrency based on the target event rate set in `MAX_EVENTS_PER_SECOND`
   RESOURCE_CALCULATION: "auto"
+
+  # Automatically define CPU, memory, message generators and concurrency based on the target event rate set in `MAX_EVENTS_PER_SECOND`
+  # overprovisioning each resource by the percentage mentioned after the comma e.g. "overprovision,20" means overprovision by 20%
+  RESOURCE_CALCULATION: "overprovision,20"
 ```
 
 #### Overriding Configuration

--- a/README.md
+++ b/README.md
@@ -253,6 +253,9 @@ env:
 
   # Memory limit if ENABLE_SOFT_MEMORY_LIMIT is true
   SOFT_MEMORY_LIMIT: "256mb"
+
+  # Automatically define CPU, memory, message generators and concurrency based on the target event rate set in `MAX_EVENTS_PER_SECOND`
+  RESOURCE_CALCULATION: "auto"
 ```
 
 #### Overriding Configuration

--- a/artifacts/helm/http_values.yaml
+++ b/artifacts/helm/http_values.yaml
@@ -35,7 +35,7 @@ deployment:
     # HOT_SOURCES: "20,20,30,30"
     USE_ONE_CLIENT_PER_SLOT: "true"
     ENABLE_SOFT_MEMORY_LIMIT: "true"
-    TOTAL_USERS: "187500"
+    TOTAL_USERS: "100000"
     # HOT_USER_GROUPS: sum should be 100 (%) and values comma separated
     # TOTAL_USERS will be divided by the number of groups and given the desired data concentration
     HOT_USER_GROUPS: "100"

--- a/artifacts/helm/http_values.yaml
+++ b/artifacts/helm/http_values.yaml
@@ -10,9 +10,9 @@ deployment:
   backoffLimit: 1
   replicas: 1
   resources:
-    cpuRequests: 500m
-    memoryRequests: 256Mi
-    cpuLimits: 2
+    cpuRequests: 1
+    memoryRequests: 2Gi
+    cpuLimits: 1
     memoryLimits: 2Gi
   ports:
     - name: metrics
@@ -23,8 +23,8 @@ deployment:
     MODE: http
     LOAD_RUN_ID: "loadRunID1" # if empty, a random UUID will be generated
     # CONCURRENCY determines how many slots are used to send data to the server.
-    CONCURRENCY: "4000" # these read from the ch
-    MESSAGE_GENERATORS: "1000" # these push into the ch
+    CONCURRENCY: "2000" # these read from the ch
+    MESSAGE_GENERATORS: "500" # these push into the ch
     MAX_EVENTS_PER_SECOND: "60000" # set as 0 for no limit
     # SOURCES should be a comma separated list of writeKeys
     # e.g. SOURCES: "write-key-1,write-key-2"

--- a/cmd/load-runner/executor.go
+++ b/cmd/load-runner/executor.go
@@ -6,13 +6,9 @@ import (
 	"os/exec"
 )
 
-type CommandExecutor interface {
-	run(ctx context.Context, name string, args ...string) error
-}
+type CommandExecutor struct{}
 
-type commandExecutor struct{}
-
-func (d *commandExecutor) run(ctx context.Context, name string, args ...string) error {
+func (d *CommandExecutor) run(ctx context.Context, name string, args ...string) error {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/load-runner/executor_test.go
+++ b/cmd/load-runner/executor_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestDefaultCommandExecutor_Run(t *testing.T) {
-	executor := &commandExecutor{}
+	executor := &CommandExecutor{}
 
 	t.Run("successful command execution", func(t *testing.T) {
 		ctx := context.Background()

--- a/cmd/load-runner/helm.go
+++ b/cmd/load-runner/helm.go
@@ -13,11 +13,11 @@ import (
 )
 
 type HelmClient struct {
-	executor CommandExecutor
+	executor commandExecutor
 	logger   logger.Logger
 }
 
-func NewHelmClient(executor CommandExecutor, logger logger.Logger) *HelmClient {
+func NewHelmClient(executor commandExecutor, logger logger.Logger) *HelmClient {
 	return &HelmClient{executor: executor, logger: logger}
 }
 

--- a/cmd/load-runner/helm.go
+++ b/cmd/load-runner/helm.go
@@ -103,61 +103,69 @@ func processHelmEnvVars(args []string, envVars map[string]string, logger logger.
 func calculateLoadParameters(args []string, envVars map[string]string, logger logger.Logger) []string {
 	resourceCalculation := envVars["RESOURCE_CALCULATION"]
 
-	// Handle auto calculation
-	if resourceCalculation == "auto" {
-		maxEventsPerSecond, err := strconv.Atoi(envVars["MAX_EVENTS_PER_SECOND"])
-		if err != nil {
-			logger.Fatal("Failed to convert MAX_EVENTS_PER_SECOND to int: %v", err)
-		}
-		resourceMultiplier := maxEventsPerSecond/5000 + 1
-		envVars["CONCURRENCY"] = strconv.Itoa(resourceMultiplier * 2000)
-		envVars["MESSAGE_GENERATORS"] = strconv.Itoa(resourceMultiplier * 500)
-		args = append(args, "--set", fmt.Sprintf("deployment.resources.cpuRequests=%d", resourceMultiplier),
-			"--set", fmt.Sprintf("deployment.resources.cpuLimits=%d", resourceMultiplier),
-			"--set", fmt.Sprintf("deployment.resources.memoryRequests=%dGi", resourceMultiplier*2),
-			"--set", fmt.Sprintf("deployment.resources.memoryLimits=%dGi", resourceMultiplier*2),
-		)
+	// If no resource calculation is specified, return args unchanged
+	if resourceCalculation == "" {
 		return args
 	}
 
-	// Handle overprovision calculation
+	// Validate resource calculation value
+	if resourceCalculation != "auto" && !strings.HasPrefix(resourceCalculation, "overprovision,") {
+		logger.Warn("Invalid RESOURCE_CALCULATION value",
+			"value", resourceCalculation,
+			"expected", "auto or overprovision,<percentage>")
+		return args
+	}
+
+	const (
+		baseEventsPerResourceUnit = 5000
+
+		concurrencyUnit = 2000
+
+		messageGeneratorsUnit = 500
+
+		cpuUnit = 1
+
+		memoryUnit = 2
+	)
+
+	maxEventsPerSecond, err := strconv.Atoi(envVars["MAX_EVENTS_PER_SECOND"])
+	if err != nil {
+		logger.Fatal("Failed to convert MAX_EVENTS_PER_SECOND to int: %v", err)
+	}
+
+	baseMultiplier := maxEventsPerSecond/baseEventsPerResourceUnit + 1
+	overprovisionFactor := 1.0
+
 	if strings.HasPrefix(resourceCalculation, "overprovision,") {
 		parts := strings.Split(resourceCalculation, ",")
 		if len(parts) != 2 {
 			logger.Fatal("Invalid RESOURCE_CALCULATION format for overprovision", "overprovision,<percentage>")
 		}
 
-		overprovisionPercent, err := strconv.Atoi(parts[1])
+		overprovisionPercentage, err := strconv.Atoi(parts[1])
 		if err != nil {
 			logger.Fatal("Failed to convert overprovision percentage to int", err)
 		}
 
-		if overprovisionPercent < 0 || overprovisionPercent > 100 {
-			logger.Fatal("Overprovision percentage must be between 0 and 100", overprovisionPercent)
+		if overprovisionPercentage < 1 || overprovisionPercentage > 100 {
+			logger.Fatal("Overprovision percentage must be between 1 and 100", overprovisionPercentage)
 		}
 
-		maxEventsPerSecond, err := strconv.Atoi(envVars["MAX_EVENTS_PER_SECOND"])
-		if err != nil {
-			logger.Fatal("Failed to convert MAX_EVENTS_PER_SECOND to int", err)
-		}
-
-		// Calculate base resource multiplier
-		baseMultiplier := maxEventsPerSecond/5000 + 1
-
-		// Apply overprovisioning
-		overprovisionFactor := 1.0 + float64(overprovisionPercent)/100.0
-		resourceMultiplier := math.Round(float64(baseMultiplier)*overprovisionFactor*100) / 100
-
-		envVars["CONCURRENCY"] = strconv.Itoa(int(resourceMultiplier * 2000))
-		envVars["MESSAGE_GENERATORS"] = strconv.Itoa(int(resourceMultiplier * 500))
-
-		args = append(args, "--set", fmt.Sprintf("deployment.resources.cpuRequests=%v", resourceMultiplier),
-			"--set", fmt.Sprintf("deployment.resources.cpuLimits=%v", resourceMultiplier),
-			"--set", fmt.Sprintf("deployment.resources.memoryRequests=%vGi", math.Round(resourceMultiplier*2)),
-			"--set", fmt.Sprintf("deployment.resources.memoryLimits=%vGi", math.Round(resourceMultiplier*2)),
-		)
-		return args
+		overprovisionFactor = 1.0 + float64(overprovisionPercentage)/100.0
 	}
 
+	resourceMultiplier := math.Round(float64(baseMultiplier)*overprovisionFactor*100) / 100
+	concurrency := resourceMultiplier * concurrencyUnit
+	messageGenerators := resourceMultiplier * messageGeneratorsUnit
+	cpu := resourceMultiplier * cpuUnit
+	memory := math.Round(resourceMultiplier * memoryUnit)
+
+	envVars["CONCURRENCY"] = strconv.Itoa(int(concurrency))
+	envVars["MESSAGE_GENERATORS"] = strconv.Itoa(int(messageGenerators))
+	args = append(args, "--set", fmt.Sprintf("deployment.resources.cpuRequests=%v", cpu),
+		"--set", fmt.Sprintf("deployment.resources.cpuLimits=%v", cpu),
+		"--set", fmt.Sprintf("deployment.resources.memoryRequests=%vGi", memory),
+		"--set", fmt.Sprintf("deployment.resources.memoryLimits=%vGi", memory),
+	)
 	return args
 }

--- a/cmd/load-runner/helm.go
+++ b/cmd/load-runner/helm.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 
@@ -103,7 +102,7 @@ func calculateLoadParameters(args []string, envVars map[string]string) []string 
 	}
 	maxEventsPerSecond, err := strconv.Atoi(envVars["MAX_EVENTS_PER_SECOND"])
 	if err != nil {
-		log.Fatalf("Failed to convert MAX_EVENTS_PER_SECOND to int: %v", err)
+		fmt.Errorf("Failed to convert MAX_EVENTS_PER_SECOND to int: %v", err)
 		return args
 	}
 	resourceMultiplier := maxEventsPerSecond/5000 + 1

--- a/cmd/load-runner/helm.go
+++ b/cmd/load-runner/helm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"strconv"
 	"strings"
 
@@ -98,21 +99,63 @@ func processHelmEnvVars(args []string, envVars map[string]string) []string {
 }
 
 func calculateLoadParameters(args []string, envVars map[string]string) []string {
-	if envVars["RESOURCE_CALCULATION"] != "auto" {
+	resourceCalculation := envVars["RESOURCE_CALCULATION"]
+
+	// Handle auto calculation
+	if resourceCalculation == "auto" {
+		maxEventsPerSecond, err := strconv.Atoi(envVars["MAX_EVENTS_PER_SECOND"])
+		if err != nil {
+			log.Fatalf("Failed to convert MAX_EVENTS_PER_SECOND to int: %v", err)
+		}
+		resourceMultiplier := maxEventsPerSecond/5000 + 1
+		envVars["CONCURRENCY"] = strconv.Itoa(resourceMultiplier * 2000)
+		envVars["MESSAGE_GENERATORS"] = strconv.Itoa(resourceMultiplier * 500)
+		args = append(args, "--set", fmt.Sprintf("deployment.resources.cpuRequests=%d", resourceMultiplier),
+			"--set", fmt.Sprintf("deployment.resources.cpuLimits=%d", resourceMultiplier),
+			"--set", fmt.Sprintf("deployment.resources.memoryRequests=%dGi", resourceMultiplier*2),
+			"--set", fmt.Sprintf("deployment.resources.memoryLimits=%dGi", resourceMultiplier*2),
+		)
 		return args
 	}
-	maxEventsPerSecond, err := strconv.Atoi(envVars["MAX_EVENTS_PER_SECOND"])
-	if err != nil {
-		log.Fatalf("Failed to convert MAX_EVENTS_PER_SECOND to int: %v", err)
+
+	// Handle overprovision calculation
+	if strings.HasPrefix(resourceCalculation, "overprovision,") {
+		parts := strings.Split(resourceCalculation, ",")
+		if len(parts) != 2 {
+			log.Fatalf("Invalid RESOURCE_CALCULATION format for overprovision. Expected 'overprovision,<percentage>'")
+		}
+
+		overprovisionPercent, err := strconv.Atoi(parts[1])
+		if err != nil {
+			log.Fatalf("Failed to convert overprovision percentage to int: %v", err)
+		}
+
+		if overprovisionPercent < 0 || overprovisionPercent > 100 {
+			log.Fatalf("Overprovision percentage must be between 0 and 100, got: %d", overprovisionPercent)
+		}
+
+		maxEventsPerSecond, err := strconv.Atoi(envVars["MAX_EVENTS_PER_SECOND"])
+		if err != nil {
+			log.Fatalf("Failed to convert MAX_EVENTS_PER_SECOND to int: %v", err)
+		}
+
+		// Calculate base resource multiplier
+		baseMultiplier := maxEventsPerSecond/5000 + 1
+
+		// Apply overprovisioning
+		overprovisionFactor := 1.0 + float64(overprovisionPercent)/100.0
+		resourceMultiplier := math.Round(float64(baseMultiplier)*overprovisionFactor*100) / 100
+
+		envVars["CONCURRENCY"] = strconv.Itoa(int(resourceMultiplier * 2000))
+		envVars["MESSAGE_GENERATORS"] = strconv.Itoa(int(resourceMultiplier * 500))
+
+		args = append(args, "--set", fmt.Sprintf("deployment.resources.cpuRequests=%v", resourceMultiplier),
+			"--set", fmt.Sprintf("deployment.resources.cpuLimits=%v", resourceMultiplier),
+			"--set", fmt.Sprintf("deployment.resources.memoryRequests=%vGi", math.Round(resourceMultiplier*2)),
+			"--set", fmt.Sprintf("deployment.resources.memoryLimits=%vGi", math.Round(resourceMultiplier*2)),
+		)
+		return args
 	}
-	resourceMultiplier := maxEventsPerSecond/5000 + 1
-	envVars["CONCURRENCY"] = strconv.Itoa(resourceMultiplier * 2000)
-	envVars["MESSAGE_GENERATORS"] = strconv.Itoa(resourceMultiplier * 500)
-	args = append(args, "--set", fmt.Sprintf("deployment.resources.cpuRequests=%d", resourceMultiplier),
-		"--set", fmt.Sprintf("deployment.resources.cpuLimits=%d", resourceMultiplier),
-		"--set", fmt.Sprintf("deployment.resources.memoryRequests=%dGi", resourceMultiplier*2),
-		"--set", fmt.Sprintf("deployment.resources.memoryLimits=%dGi", resourceMultiplier*2),
-	)
 
 	return args
 }

--- a/cmd/load-runner/helm.go
+++ b/cmd/load-runner/helm.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
@@ -102,8 +103,7 @@ func calculateLoadParameters(args []string, envVars map[string]string) []string 
 	}
 	maxEventsPerSecond, err := strconv.Atoi(envVars["MAX_EVENTS_PER_SECOND"])
 	if err != nil {
-		fmt.Errorf("Failed to convert MAX_EVENTS_PER_SECOND to int: %v", err)
-		return args
+		log.Fatalf("Failed to convert MAX_EVENTS_PER_SECOND to int: %v", err)
 	}
 	resourceMultiplier := maxEventsPerSecond/5000 + 1
 	envVars["CONCURRENCY"] = strconv.Itoa(resourceMultiplier * 2000)

--- a/cmd/load-runner/helm.go
+++ b/cmd/load-runner/helm.go
@@ -12,22 +12,16 @@ import (
 	"rudder-load/internal/parser"
 )
 
-type HelmClient interface {
-	Install(ctx context.Context, config *parser.LoadTestConfig) error
-	Upgrade(ctx context.Context, config *parser.LoadTestConfig, phase parser.RunPhase) error
-	Uninstall(config *parser.LoadTestConfig) error
-}
-
-type helmClient struct {
+type HelmClient struct {
 	executor CommandExecutor
 	logger   logger.Logger
 }
 
-func NewHelmClient(executor CommandExecutor, logger logger.Logger) *helmClient {
-	return &helmClient{executor: executor, logger: logger}
+func NewHelmClient(executor CommandExecutor, logger logger.Logger) *HelmClient {
+	return &HelmClient{executor: executor, logger: logger}
 }
 
-func (h *helmClient) Install(ctx context.Context, config *parser.LoadTestConfig) error {
+func (h *HelmClient) Install(ctx context.Context, config *parser.LoadTestConfig) error {
 	args := []string{
 		"install",
 		config.ReleaseName,
@@ -47,7 +41,7 @@ func (h *helmClient) Install(ctx context.Context, config *parser.LoadTestConfig)
 	return h.executor.run(ctx, "helm", args...)
 }
 
-func (h *helmClient) Upgrade(ctx context.Context, config *parser.LoadTestConfig, phase parser.RunPhase) error {
+func (h *HelmClient) Upgrade(ctx context.Context, config *parser.LoadTestConfig, phase parser.RunPhase) error {
 	args := []string{
 		"upgrade",
 		config.ReleaseName,
@@ -85,7 +79,7 @@ func (h *helmClient) Upgrade(ctx context.Context, config *parser.LoadTestConfig,
 	return h.executor.run(ctx, "helm", args...)
 }
 
-func (h *helmClient) Uninstall(config *parser.LoadTestConfig) error {
+func (h *HelmClient) Uninstall(config *parser.LoadTestConfig) error {
 	args := []string{
 		"uninstall",
 		config.ReleaseName,

--- a/cmd/load-runner/helm_test.go
+++ b/cmd/load-runner/helm_test.go
@@ -12,7 +12,6 @@ import (
 	"rudder-load/internal/parser"
 )
 
-// MockExecutor implements CommandExecutor interface for testing
 type MockExecutor struct {
 	mock.Mock
 }

--- a/cmd/load-runner/helm_test.go
+++ b/cmd/load-runner/helm_test.go
@@ -502,12 +502,10 @@ func TestCalculateLoadParameters(t *testing.T) {
 		{
 			name: "auto calculation disabled",
 			envVars: map[string]string{
-				"RESOURCE_CALCULATION":  "manual",
 				"MAX_EVENTS_PER_SECOND": "10000",
 			},
 			expectedArgs: []string{},
 			expectedEnvVars: map[string]string{
-				"RESOURCE_CALCULATION":  "manual",
 				"MAX_EVENTS_PER_SECOND": "10000",
 			},
 		},
@@ -516,6 +514,63 @@ func TestCalculateLoadParameters(t *testing.T) {
 			envVars:         map[string]string{},
 			expectedArgs:    []string{},
 			expectedEnvVars: map[string]string{},
+		},
+		{
+			name: "overprovision calculation with 10%",
+			envVars: map[string]string{
+				"RESOURCE_CALCULATION":  "overprovision,10",
+				"MAX_EVENTS_PER_SECOND": "10000",
+			},
+			expectedArgs: []string{
+				"--set", "deployment.resources.cpuRequests=3.3",
+				"--set", "deployment.resources.cpuLimits=3.3",
+				"--set", "deployment.resources.memoryRequests=7Gi",
+				"--set", "deployment.resources.memoryLimits=7Gi",
+			},
+			expectedEnvVars: map[string]string{
+				"RESOURCE_CALCULATION":  "overprovision,10",
+				"MAX_EVENTS_PER_SECOND": "10000",
+				"CONCURRENCY":           "6600",
+				"MESSAGE_GENERATORS":    "1650",
+			},
+		},
+		{
+			name: "overprovision calculation with 50%",
+			envVars: map[string]string{
+				"RESOURCE_CALCULATION":  "overprovision,50",
+				"MAX_EVENTS_PER_SECOND": "10000",
+			},
+			expectedArgs: []string{
+				"--set", "deployment.resources.cpuRequests=4.5",
+				"--set", "deployment.resources.cpuLimits=4.5",
+				"--set", "deployment.resources.memoryRequests=9Gi",
+				"--set", "deployment.resources.memoryLimits=9Gi",
+			},
+			expectedEnvVars: map[string]string{
+				"RESOURCE_CALCULATION":  "overprovision,50",
+				"MAX_EVENTS_PER_SECOND": "10000",
+				"CONCURRENCY":           "9000",
+				"MESSAGE_GENERATORS":    "2250",
+			},
+		},
+		{
+			name: "overprovision calculation with 100%",
+			envVars: map[string]string{
+				"RESOURCE_CALCULATION":  "overprovision,100",
+				"MAX_EVENTS_PER_SECOND": "10000",
+			},
+			expectedArgs: []string{
+				"--set", "deployment.resources.cpuRequests=6",
+				"--set", "deployment.resources.cpuLimits=6",
+				"--set", "deployment.resources.memoryRequests=12Gi",
+				"--set", "deployment.resources.memoryLimits=12Gi",
+			},
+			expectedEnvVars: map[string]string{
+				"RESOURCE_CALCULATION":  "overprovision,100",
+				"MAX_EVENTS_PER_SECOND": "10000",
+				"CONCURRENCY":           "12000",
+				"MESSAGE_GENERATORS":    "3000",
+			},
 		},
 	}
 

--- a/cmd/load-runner/helm_test.go
+++ b/cmd/load-runner/helm_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/rudderlabs/rudder-go-kit/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -24,7 +25,7 @@ func (m *MockExecutor) run(ctx context.Context, command string, args ...string) 
 func TestHelmClient_Install(t *testing.T) {
 	// Setup
 	mockExecutor := new(MockExecutor)
-	helmClient := NewHelmClient(mockExecutor)
+	helmClient := NewHelmClient(mockExecutor, logger.NOP)
 	ctx := context.Background()
 
 	config := &parser.LoadTestConfig{
@@ -58,7 +59,7 @@ func TestHelmClient_Install(t *testing.T) {
 func TestHelmClient_Install_WithEnvOverrides(t *testing.T) {
 	// Setup
 	mockExecutor := new(MockExecutor)
-	helmClient := NewHelmClient(mockExecutor)
+	helmClient := NewHelmClient(mockExecutor, logger.NOP)
 	ctx := context.Background()
 
 	config := &parser.LoadTestConfig{
@@ -118,7 +119,7 @@ func TestHelmClient_Install_WithEnvOverrides(t *testing.T) {
 func TestHelmClient_Upgrade(t *testing.T) {
 	// Setup
 	mockExecutor := new(MockExecutor)
-	helmClient := NewHelmClient(mockExecutor)
+	helmClient := NewHelmClient(mockExecutor, logger.NOP)
 	ctx := context.Background()
 
 	config := &parser.LoadTestConfig{
@@ -157,7 +158,7 @@ func TestHelmClient_Upgrade(t *testing.T) {
 func TestHelmClient_Upgrade_WithGlobalEnvOverrides(t *testing.T) {
 	// Setup
 	mockExecutor := new(MockExecutor)
-	helmClient := NewHelmClient(mockExecutor)
+	helmClient := NewHelmClient(mockExecutor, logger.NOP)
 	ctx := context.Background()
 
 	config := &parser.LoadTestConfig{
@@ -222,7 +223,7 @@ func TestHelmClient_Upgrade_WithGlobalEnvOverrides(t *testing.T) {
 func TestHelmClient_Upgrade_WithPhaseEnvOverrides(t *testing.T) {
 	// Setup
 	mockExecutor := new(MockExecutor)
-	helmClient := NewHelmClient(mockExecutor)
+	helmClient := NewHelmClient(mockExecutor, logger.NOP)
 	ctx := context.Background()
 
 	config := &parser.LoadTestConfig{
@@ -291,7 +292,7 @@ func TestHelmClient_Upgrade_WithPhaseEnvOverrides(t *testing.T) {
 
 func TestHelmClient_Install_WithCommaEscaping(t *testing.T) {
 	mockExecutor := new(MockExecutor)
-	helmClient := NewHelmClient(mockExecutor)
+	helmClient := NewHelmClient(mockExecutor, logger.NOP)
 	ctx := context.Background()
 
 	config := &parser.LoadTestConfig{
@@ -345,7 +346,7 @@ func TestHelmClient_Install_WithCommaEscaping(t *testing.T) {
 
 func TestHelmClient_Upgrade_WithCommaEscaping(t *testing.T) {
 	mockExecutor := new(MockExecutor)
-	helmClient := NewHelmClient(mockExecutor)
+	helmClient := NewHelmClient(mockExecutor, logger.NOP)
 	ctx := context.Background()
 
 	config := &parser.LoadTestConfig{
@@ -405,7 +406,7 @@ func TestHelmClient_Upgrade_WithCommaEscaping(t *testing.T) {
 func TestHelmClient_Uninstall(t *testing.T) {
 	// Setup
 	mockExecutor := new(MockExecutor)
-	helmClient := NewHelmClient(mockExecutor)
+	helmClient := NewHelmClient(mockExecutor, logger.NOP)
 
 	config := &parser.LoadTestConfig{
 		ReleaseName: "test-release",
@@ -432,7 +433,7 @@ func TestHelmClient_Uninstall(t *testing.T) {
 func TestHelmClient_Install_Error(t *testing.T) {
 	// Setup
 	mockExecutor := new(MockExecutor)
-	helmClient := NewHelmClient(mockExecutor)
+	helmClient := NewHelmClient(mockExecutor, logger.NOP)
 	ctx := context.Background()
 
 	config := &parser.LoadTestConfig{
@@ -583,7 +584,7 @@ func TestCalculateLoadParameters(t *testing.T) {
 			}
 
 			// Call the function
-			args := calculateLoadParameters([]string{}, inputEnvVars)
+			args := calculateLoadParameters([]string{}, inputEnvVars, logger.NOP)
 
 			// Verify the returned args
 			assert.Equal(t, tt.expectedArgs, args, "args mismatch")

--- a/cmd/load-runner/helm_test.go
+++ b/cmd/load-runner/helm_test.go
@@ -245,7 +245,7 @@ func TestHelmClient_Upgrade_WithPhaseEnvOverrides(t *testing.T) {
 	}
 
 	mockExecutor.On("run", ctx, "helm", mock.MatchedBy(func(args []string) bool {
-		if len(args) != 21 {
+		if len(args) != 19 {
 			return false
 		}
 
@@ -276,8 +276,7 @@ func TestHelmClient_Upgrade_WithPhaseEnvOverrides(t *testing.T) {
 			}
 		}
 
-		return envVarSet["deployment.env.MESSAGE_GENERATORS=200"] &&
-			envVarSet["deployment.env.MAX_EVENTS_PER_SECOND=15000"] &&
+		return envVarSet["deployment.env.MAX_EVENTS_PER_SECOND=15000"] &&
 			envVarSet["deployment.env.MESSAGE_GENERATORS=300"] &&
 			envVarSet["deployment.env.CONCURRENCY=500"]
 	})).Return(nil)

--- a/cmd/load-runner/helm_test.go
+++ b/cmd/load-runner/helm_test.go
@@ -517,18 +517,6 @@ func TestCalculateLoadParameters(t *testing.T) {
 			expectedArgs:    []string{},
 			expectedEnvVars: map[string]string{},
 		},
-		{
-			name: "non integer MAX_EVENTS_PER_SECOND",
-			envVars: map[string]string{
-				"RESOURCE_CALCULATION":  "auto",
-				"MAX_EVENTS_PER_SECOND": "invalid",
-			},
-			expectedArgs: []string{},
-			expectedEnvVars: map[string]string{
-				"RESOURCE_CALCULATION":  "auto",
-				"MAX_EVENTS_PER_SECOND": "invalid",
-			},
-		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/load-runner/main.go
+++ b/cmd/load-runner/main.go
@@ -10,9 +10,9 @@ import (
 	"github.com/rudderlabs/rudder-go-kit/logger"
 	obskit "github.com/rudderlabs/rudder-observability-kit/go/labels"
 
+	"rudder-load/internal/metrics"
 	"rudder-load/internal/parser"
 	"rudder-load/internal/validator"
-	"rudder-load/internal/metrics"
 )
 
 func main() {
@@ -51,7 +51,7 @@ func run(ctx context.Context, log logger.Logger) error {
 
 	cfg.SetDefaults()
 
-	helmClient := NewHelmClient(&commandExecutor{})
+	helmClient := NewHelmClient(&commandExecutor{}, log)
 	mimirClient := metrics.NewMimirClient("http://localhost:9898")
 	runner := NewLoadTestRunner(cfg, helmClient, mimirClient, log)
 

--- a/cmd/load-runner/main.go
+++ b/cmd/load-runner/main.go
@@ -15,6 +15,10 @@ import (
 	"rudder-load/internal/validator"
 )
 
+type commandExecutor interface {
+	run(ctx context.Context, name string, args ...string) error
+}
+
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
@@ -51,7 +55,7 @@ func run(ctx context.Context, log logger.Logger) error {
 
 	cfg.SetDefaults()
 
-	helmClient := NewHelmClient(&commandExecutor{}, log)
+	helmClient := NewHelmClient(&CommandExecutor{}, log)
 	mimirClient := metrics.NewMimirClient("http://localhost:9898")
 	runner := NewLoadTestRunner(cfg, helmClient, mimirClient, log)
 

--- a/cmd/load-runner/runner.go
+++ b/cmd/load-runner/runner.go
@@ -13,15 +13,21 @@ import (
 	"rudder-load/internal/parser"
 )
 
+type helmClient interface {
+	Install(ctx context.Context, config *parser.LoadTestConfig) error
+	Upgrade(ctx context.Context, config *parser.LoadTestConfig, phase parser.RunPhase) error
+	Uninstall(config *parser.LoadTestConfig) error
+}
+
 type LoadTestRunner struct {
 	config      *parser.LoadTestConfig
-	helmClient  HelmClient
+	helmClient  helmClient
 	mimirClient metrics.MimirClient
 	portForward *metrics.PortForward
 	logger      logger.Logger
 }
 
-func NewLoadTestRunner(config *parser.LoadTestConfig, helmClient HelmClient, mimirClient metrics.MimirClient, logger logger.Logger) *LoadTestRunner {
+func NewLoadTestRunner(config *parser.LoadTestConfig, helmClient helmClient, mimirClient metrics.MimirClient, logger logger.Logger) *LoadTestRunner {
 	return &LoadTestRunner{
 		config:      config,
 		helmClient:  helmClient,

--- a/cmd/load-runner/runner_test.go
+++ b/cmd/load-runner/runner_test.go
@@ -17,7 +17,6 @@ import (
 	"rudder-load/internal/parser"
 )
 
-// MockHelmClient implements HelmClient interface for testing
 type MockHelmClient struct {
 	mock.Mock
 }

--- a/tests/constant_load_auto.test.yaml
+++ b/tests/constant_load_auto.test.yaml
@@ -1,0 +1,21 @@
+# This test maintains a constant load throughout the test duration
+# with equal distribution of users, events, and sources
+
+name: http
+namespace: rudder-load
+env:
+  MAX_EVENTS_PER_SECOND: "5000"
+  TOTAL_USERS: "100000"
+  HOT_USER_GROUPS: "50,50"
+  EVENT_TYPES: "track,page,identify"
+  HOT_EVENT_TYPES: "33,33,34"
+  RESOURCE_CALCULATION: "auto"
+phases:
+  - duration: 5m
+    replicas: 1
+    env:
+      MAX_EVENTS_PER_SECOND: "5000"
+  - duration: 5m
+    replicas: 1
+    env:
+      MAX_EVENTS_PER_SECOND: "10000"

--- a/tests/constant_load_overprovisioning.test.yaml
+++ b/tests/constant_load_overprovisioning.test.yaml
@@ -1,6 +1,6 @@
 # This test maintains a constant load throughout the test duration
 # with equal distribution of users, events, and sources
-# The test automatically calculates the resources based on the target event rate
+# The test overprovisions the resources by 10% based on the target event rate
 
 name: http
 namespace: rudder-load
@@ -10,7 +10,7 @@ env:
   HOT_USER_GROUPS: "50,50"
   EVENT_TYPES: "track,page,identify"
   HOT_EVENT_TYPES: "33,33,34"
-  RESOURCE_CALCULATION: "auto"
+  RESOURCE_CALCULATION: "overprovision,10"
 phases:
   - duration: 5m
     replicas: 1

--- a/tests/reporting.test.yaml
+++ b/tests/reporting.test.yaml
@@ -6,6 +6,8 @@ env:
   MAX_EVENTS_PER_SECOND: 100
   CONCURRENCY: 100
   MESSAGE_GENERATORS: 100
+  EVENT_TYPES: "track,page,identify"
+  HOT_EVENT_TYPES: "33,33,34"
 phases:
   - duration: 15m
     replicas: 2


### PR DESCRIPTION
## Description of the change

> This PR adds two mechanisms that automatically calculate the resources for the load pods (CPU, memory, concurrency, message generators) based on the target event rate.
The mechanisms are triggered by setting the `RESOURCE_CALCULATION` env var. 
If the value is set to `auto` the resources are calculated based one the value set for `MAX_EVENTS_PER_SECOND` env var.
If the value is set to `overprovision,X` the resources are calculated based one the value set for `MAX_EVENTS_PER_SECOND` env var and the calculated resources are increased by X% so that the load pods have some extra capacity for cases it might be necessary.
If the env var is not specified then the resources are explicitly set by the test file, load-runner configuration or the values file.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
