### PR TITLE
feat: ok responder

### DIFF
--- a/artifacts/ok_deployment.yaml
+++ b/artifacts/ok_deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ok-responder
+  labels:
+    app: ok-responder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ok-responder
+  template:
+    metadata:
+      labels:
+        app: ok-responder
+    spec:
+      restartPolicy: Always
+      hostname: ok-responder
+      subdomain: oksubdomain
+      containers:
+        - name: http-echo
+          image: hashicorp/http-echo
+          args:
+            - "-text=OK"
+            - "-listen=:5678"
+          ports:
+            - containerPort: 5678
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ok-responder
+  name: oksubdomain
+spec:
+  ports:
+  - port: 5678
+    protocol: TCP
+    targetPort: 5678
+  selector:
+    app: ok-responder
+  clusterIP: None


### PR DESCRIPTION
🔒 Scanned for secrets using gitleaks version is set by build process

As usual just do `kubectl apply -f artifacts/ok_deployment.yaml`.

Then use as you wish, for example I'm using it for testing `fetch` calls in UTs:

```js
/***  
* This is a custom transformation template for building transformations from scratch.
* Learn more by visiting https://www.rudderstack.com/docs/features/transformations/templates/
***/

export async function transformEvent(event, metadata) {
    try {
        await fetchV2("http://ok-responder.oksubdomain:5678");
        event["status"] = "ok";
    } catch {
        event["status"] = "err";
    }
    return event;
}
```